### PR TITLE
Change `lounge` GitHub topic to `thelounge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Clone this Git repo and build the image with `docker build -t mylounge .`.
 You can set `GIT_REV` to any branch, tag or commit hash when building image like this:
 
 ```
-docker build --build-arg GIT_REV=v2.4.0 -t mylounge .
+docker build --build-arg GIT_REV=v2.7.0 -t mylounge .
 ```
 
 ## Running Container


### PR DESCRIPTION
**This is a dummy commit, do not merge.**

Hey, sorry to open a PR for this, but it seems you disabled the issues on this repo :man_shrugging: 

Would you mind changing the topic on this repo from `lounge` to `thelounge` so it appears [on the actual topic page](https://github.com/topics/thelounge)?
A few people have been looking to do something like this recently.